### PR TITLE
Fix incomplete LICENSE file (fill in placeholders)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2021 Ryan Bester
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi!

I noticed that the `LICENSE` file still contained the placeholders `[year]` and `[fullname]`.
I have updated them based on the repository history to clarify the copyright status.

This change does not affect the code but ensures the license is legally valid.